### PR TITLE
LIBASPACE-122 Bump Aspace version to 2.2.2

### DIFF
--- a/scripts/aspace.sh
+++ b/scripts/aspace.sh
@@ -3,7 +3,7 @@
 SERVICE_USER_GROUP=vagrant:vagrant
 
 # Aspace
-ASPACE_VERSION=2.1.2
+ASPACE_VERSION=2.2.2
 ASPACE_PKG=/apps/dist/archivesspace-v${ASPACE_VERSION}.zip
 # look for a cached tarball
 if [ ! -e "$ASPACE_PKG" ]; then


### PR DESCRIPTION
This bumps the aspace version to 2.2.2. Be sure to add a copy of the
release to teh dist directory.

https://issues.umd.edu/browse/LIBASPACE-122