### PR TITLE
LIBASPACE-63 Use Docker configuration

### DIFF
--- a/manifests/aspace.pp
+++ b/manifests/aspace.pp
@@ -24,7 +24,9 @@ package { 'mod_ssl':
   ensure  => present,
   require => Package['httpd'],
 }
-package { 'mysql-server':
+
+include 'docker'
+class { 'docker::compose':
   ensure => present,
 }
 

--- a/scripts/database.sh
+++ b/scripts/database.sh
@@ -1,19 +1,7 @@
 #/bin/bash
 
-MYSQL_JDBC_VERSION=5.1.38
-
-# install JDBC driver
-cd /apps/aspace/archivesspace
-curl -Lso lib/mysql-connector-java-${MYSQL_JDBC_VERSION}.jar \
-    https://maven.lib.umd.edu/nexus/service/local/repositories/central/content/mysql/mysql-connector-java/${MYSQL_JDBC_VERSION}/mysql-connector-java-${MYSQL_JDBC_VERSION}.jar
-
-# set up MySQL database
 mysql -u root <<END
 CREATE DATABASE archivesspace default character set utf8;
 CREATE USER 'as'@'localhost' IDENTIFIED BY 'as';
 GRANT ALL PRIVILEGES ON archivesspace.* TO 'as'@'localhost';
 END
-
-# create tables
-source /apps/aspace/config/env
-scripts/setup-database.sh

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -7,4 +7,3 @@ ENV_TARGET_DIR=/apps/aspace
 
 git clone "file://$ENV_SRC_DIR/.git" "$ENV_TARGET_DIR"
 chown -R "$SERVICE_USER_GROUP" "$ENV_TARGET_DIR"
-chmod -R +x $ENV_TARGET_DIR/scripts

--- a/scripts/env_no_git.sh
+++ b/scripts/env_no_git.sh
@@ -2,9 +2,7 @@
 
 SERVICE_USER_GROUP=vagrant:vagrant
 
-ENV_SRC_DIR=/apps/git/aspace-env
+ENV_SRC_DIR=/apps/git/aspace-env/
 ENV_TARGET_DIR=/apps/aspace
-
-cp -r $ENV_SRC_DIR $ENV_TARGET_DIR
+rsync -av --progress $ENV_SRC_DIR $ENV_TARGET_DIR --exclude .git
 chown -R "$SERVICE_USER_GROUP" "$ENV_TARGET_DIR"
-chmod -R +x $ENV_TARGET_DIR/scripts

--- a/scripts/fix_puppet_gpg.sh
+++ b/scripts/fix_puppet_gpg.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd /tmp
+curl --remote-name --location https://yum.puppetlabs.com/RPM-GPG-KEY-puppet
+gpg --keyid-format 0xLONG --with-fingerprint ./RPM-GPG-KEY-puppet
+rpm --import RPM-GPG-KEY-puppet

--- a/scripts/https-cert.sh
+++ b/scripts/https-cert.sh
@@ -49,4 +49,4 @@ END
         -extensions v3_req -extfile "$CNF"
 fi
 
-cp -rp "$DIST_DIR/$HOSTNAME/ssl" /apps
+find "$DIST_DIR/$HOSTNAME/ssl" -type f -exec cp {} /apps/aspace/ssl/certs \;


### PR DESCRIPTION
This sets up the Vagrant to use the Dockerized Aspace ENV.
The configuration can be see in the docker-compose-vagrant.yml.
The vagrant uses the Aspace, Nginx, and MySQL containers, but not the
Solr container. Solr is still setup in its own Vagrant VM, which aspace
is configured to use in the docker-compose.yml file.

https://issues.umd.edu/browse/LIBASPACE-163